### PR TITLE
fix: explicitly emit click from VButton so named slot handlers fire c…

### DIFF
--- a/src/minimal-ui/lib/VButton.vue
+++ b/src/minimal-ui/lib/VButton.vue
@@ -1,9 +1,10 @@
 <template>
-  <button :class="['btn', variant]"><slot /></button>
+  <button :class="['btn', variant]" @click="emit('click', $event)"><slot /></button>
 </template>
 <script setup lang="ts">
 defineOptions({ name: 'VButton' })
 defineProps({ variant: { type: String, default: 'default' } })
+const emit = defineEmits(['click'])
 </script>
 <style lang="scss" scoped>
 .btn {


### PR DESCRIPTION
…orrectly

Vue 3 fallthrough attributes do not reliably propagate @click when a component is used inside a named slot. Adding defineEmits(['click']) and forwarding the native click event ensures ok()/cancel() handlers in all modal #footer slots are called.

https://claude.ai/code/session_01Jymcp8vAL2pGVnRmPdGsp7