### PR TITLE
fix: add deep watch to EditNodeModal/EditLinkModal so mutation of rea…

### DIFF
--- a/src/DiagramEditor.vue
+++ b/src/DiagramEditor.vue
@@ -216,6 +216,7 @@ function openNodeEdit(item) {
 }
 
 function editNode(item) {
+  isEditModalActive.value = false
   const tmp = graphData.value.nodes.find(x => x.id === item.id)
   if (!tmp) return
   tmp.content.text = item.content.text
@@ -250,6 +251,7 @@ function openLinkEdit(item) {
 }
 
 function editLink(item) {
+  isEditLinkModalActive.value = false
   const tmp = graphData.value.links.find(x => x.id === item.id)
   if (!tmp) return
   tmp.color = item.content.color

--- a/src/lib/EditLinkModal.vue
+++ b/src/lib/EditLinkModal.vue
@@ -68,7 +68,7 @@ const newLink = ref({ ...props.link.content })
 
 watch(() => props.link, val => {
   newLink.value = { ...val.content }
-})
+}, { deep: true })
 
 function ok() {
   emit('ok', { id: props.link.id, content: { ...newLink.value } })

--- a/src/lib/EditNodeModal.vue
+++ b/src/lib/EditNodeModal.vue
@@ -96,7 +96,7 @@ const newNode = ref({ ...props.node, content: { ...props.node.content } })
 
 watch(() => props.node, val => {
   newNode.value = { ...val, content: { ...val.content } }
-})
+}, { deep: true })
 
 function ok() { emit('ok', newNode.value) }
 function cancel() { emit('cancel') }


### PR DESCRIPTION
…ctive prop triggers update

tmpNode/tmpLink are reactive objects mutated in-place via Object.assign. Without { deep: true }, watch(() => props.node) never fires since the reference stays the same, leaving newNode.id empty and causing editNode's find() guard to return early without closing the modal.

Also close modals defensively at the start of editNode/editLink.

https://claude.ai/code/session_01Jymcp8vAL2pGVnRmPdGsp7