### PR TITLE
fix: align arrow tip to node edge by setting marker refX="10"

### DIFF
--- a/src/lib/Link.vue
+++ b/src/lib/Link.vue
@@ -31,7 +31,7 @@
         markerWidth="12"
         markerHeight="12"
         viewBox="0 0 10 10"
-        refX="5"
+        refX="10"
         refY="5"
       >
         <polygon points="0,2 0,8 10,5" :fill="link.color || '#6366f1'" />


### PR DESCRIPTION
refX="5" placed the arrow midpoint at the path endpoint, causing the arrowhead to extend 5 units into the destination node. refX="10" places the tip exactly at the path endpoint (node boundary).

https://claude.ai/code/session_01Jymcp8vAL2pGVnRmPdGsp7