### PR TITLE
Fix Quick Start code blocks overflowing grid column

### DIFF
--- a/src/demo/App.vue
+++ b/src/demo/App.vue
@@ -622,6 +622,7 @@ a { color: inherit; text-decoration: none; }
   display: flex;
   flex-direction: column;
   gap: 20px;
+  min-width: 0;
 }
 .code-block {
   border-radius: 10px;
@@ -643,6 +644,7 @@ a { color: inherit; text-decoration: none; }
   padding: 16px;
   background: rgba(255,255,255,0.03);
   overflow-x: auto;
+  min-width: 0;
 }
 .code-block code {
   font-family: 'Courier New', monospace;


### PR DESCRIPTION
Add min-width: 0 to .quickstart-code and .code-block pre so grid items can shrink below their content size and overflow-x: auto on pre elements takes effect correctly.

https://claude.ai/code/session_01Jymcp8vAL2pGVnRmPdGsp7